### PR TITLE
Configure Tailwind PostCSS plugins for CSS processing

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}


### PR DESCRIPTION
## Summary
- add Tailwind and autoprefixer plugins to PostCSS config for proper CSS processing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0b73c87b4832b94474004506725eb