### PR TITLE
refactor: use TypeScript tailwind config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: { config: './tailwind.config.ts' },
     autoprefixer: {},
   },
 };

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "tailwind.config.ts"]
 }


### PR DESCRIPTION
## Summary
- drop CommonJS Tailwind config in favor of TypeScript version
- wire PostCSS to the TypeScript Tailwind config
- include Tailwind config in Node tsconfig for type checking

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c676e878832bb185949a52df56b4