### PR TITLE
fix lint semi rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,6 @@ export default tseslint.config([
     },
     rules: {
       semi: ['error', 'always'],
-      '@/semi': ['error', 'always'],
     },
   },
 ]);


### PR DESCRIPTION
## Summary
- remove incorrect `@/semi` rule from ESLint config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9ea03dc832b888c9cd1d62d6b04