### PR TITLE
feat: persist templates to local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Review Launcher is a lightweight web app that helps customers quickly post Googl
 3. Click **Open Review Box** to launch Google Maps.
 4. Paste the review, add a rating and submit.
 
+## Template Persistence
+
+Custom templates are saved in your browser's `localStorage`. They are loaded when the app starts and automatically updated whenever templates are added, removed, or generated, so your changes persist across sessions.
+
 ## Additional Scripts
 
 Create a production build:

--- a/src/review-launcher.tsx
+++ b/src/review-launcher.tsx
@@ -13,6 +13,24 @@ const ReviewLauncher = () => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [templates, setTemplates] = useState<Record<BusinessKey, string[]>>(initialTemplates);
 
+  useEffect(() => {
+    const stored = localStorage.getItem('templates');
+    if (stored) {
+      try {
+        setTemplates(JSON.parse(stored) as Record<BusinessKey, string[]>);
+      } catch (err) {
+        console.error('Failed to parse templates from localStorage', err);
+        setTemplates(initialTemplates);
+      }
+    } else {
+      setTemplates(initialTemplates);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('templates', JSON.stringify(templates));
+  }, [templates]);
+
   const handleLaunchReview = async () => {
     const reviewText = templates[selectedBusiness][selectedTemplate];
     const business = businesses[selectedBusiness];


### PR DESCRIPTION
## Summary
- load saved templates from localStorage when the app mounts
- persist template changes back to localStorage
- document template persistence in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9f098ac832b9cb180123caad8eb