### PR TITLE
Add security flags to WhatsApp share window

### DIFF
--- a/src/review-launcher.tsx
+++ b/src/review-launcher.tsx
@@ -148,7 +148,8 @@ const ReviewLauncher = () => {
     const appUrl = window.location.href;
     const message = `✨ Help us grow! Use this Review Launcher to easily post reviews for our jewellery stores:\n\n${appUrl}\n\nJust copy the review and paste it on Google Maps. Thank you for your support! 💍✔️`;
     const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(message)}`;
-    window.open(whatsappUrl, '_blank');
+    const newWindow = window.open(whatsappUrl, '_blank', 'noopener,noreferrer');
+    if (newWindow) newWindow.opener = null;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Use `window.open` with `noopener,noreferrer` for WhatsApp share links
- Ensure the new window cannot access the opener

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9ed24e0832bab97791b3c43b0f1