### PR TITLE
feat: expand silver and gold keyword lists

### DIFF
--- a/src/review-launcher.tsx
+++ b/src/review-launcher.tsx
@@ -97,6 +97,9 @@ const ReviewLauncher = () => {
             'craftsmanship',
             'wedding jewelry',
             'gold collection',
+            'wholesale rate',
+            'genuine rates',
+            'fair market prices',
           ]
         : [
             '925 hallmark silver',
@@ -109,6 +112,11 @@ const ReviewLauncher = () => {
             'silver collection',
             'handcrafted silver',
             'premium silver',
+            'wholesale',
+            'silver utensils',
+            'silver coins',
+            'silver murti',
+            'silver idols',
           ];
 
     const openings = [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- expand gold keywords with wholesale and pricing related terms
- add more silver keywords including wholesale and popular item types

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0d250076c832b8bad24118457a9f8