### PR TITLE
feat: allow staff acknowledgements

### DIFF
--- a/src/components/ReviewActions.tsx
+++ b/src/components/ReviewActions.tsx
@@ -3,13 +3,34 @@ import { Copy, ExternalLink } from 'lucide-react';
 interface ReviewActionsProps {
   onLaunch: () => void;
   copySuccess: string;
+  staffName: string;
+  setStaffName: (value: string) => void;
 }
 
-const ReviewActions = ({ onLaunch, copySuccess }: ReviewActionsProps) => (
+const ReviewActions = ({
+  onLaunch,
+  copySuccess,
+  staffName,
+  setStaffName,
+}: ReviewActionsProps) => (
   <div className="bg-white rounded-lg shadow-lg p-4 sm:p-6 md:p-8 mb-4 sm:mb-6 md:mb-8">
     <h2 className="text-lg sm:text-xl md:text-2xl font-semibold mb-3 sm:mb-4">
       Launch Review
     </h2>
+
+    <div className="mb-4">
+      <label className="block text-sm sm:text-base font-medium text-gray-700 mb-2">
+        Staff member who helped you (optional)
+      </label>
+      <input
+        type="text"
+        value={staffName}
+        onChange={(e) => setStaffName(e.target.value)}
+        placeholder="Enter staff name"
+        className="w-full p-3 sm:p-4 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm sm:text-base min-h-[44px]"
+      />
+    </div>
+
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
       <button
         onClick={onLaunch}

--- a/src/review-launcher.tsx
+++ b/src/review-launcher.tsx
@@ -12,6 +12,7 @@ const ReviewLauncher = () => {
   const [copySuccess, setCopySuccess] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [templates, setTemplates] = useState<Record<BusinessKey, string[]>>(initialTemplates);
+  const [staffName, setStaffName] = useState('');
 
   useEffect(() => {
     const stored = localStorage.getItem('templates');
@@ -32,8 +33,20 @@ const ReviewLauncher = () => {
   }, [templates]);
 
   const handleLaunchReview = async () => {
-    const reviewText = templates[selectedBusiness][selectedTemplate];
+    let reviewText = templates[selectedBusiness][selectedTemplate];
     const business = businesses[selectedBusiness];
+
+    if (staffName.trim()) {
+      const thanksMessages = [
+        `A big thank you to ${staffName} for all their help.`,
+        `${staffName} was incredibly helpful throughout my visit.`,
+        `Kudos to ${staffName} for the excellent service.`,
+        `Thanks to ${staffName} for making my experience great.`,
+      ];
+      const randomThanks =
+        thanksMessages[Math.floor(Math.random() * thanksMessages.length)];
+      reviewText += ` ${randomThanks}`;
+    }
 
     try {
       if ('clipboard' in navigator) {
@@ -240,7 +253,12 @@ const ReviewLauncher = () => {
           isGenerating={isGenerating}
         />
 
-        <ReviewActions onLaunch={handleLaunchReview} copySuccess={copySuccess} />
+        <ReviewActions
+          onLaunch={handleLaunchReview}
+          copySuccess={copySuccess}
+          staffName={staffName}
+          setStaffName={setStaffName}
+        />
 
         <ShareTool onShare={handleWhatsAppShare} />
       </div>


### PR DESCRIPTION
## Summary
- allow customers to optionally enter the staff member who helped them
- thank named staff with a random message when launching a review

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49579fd38832ba56423cdcbcf01ed