### PR TITLE
feat: personalize reviews with staff mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,16 @@ Review Launcher is a lightweight web app that helps customers quickly post Googl
 ## Using the App
 
 1. Select a business from the dropdown.
-2. Copy one of the suggested review templates.
-3. Click **Open Review Box** to launch Google Maps.
-4. Paste the review, add a rating and submit.
+2. (Optional) Enter the name of the staff member who helped you.
+3. Copy one of the suggested review templates. The preview will highlight the staff name.
+4. Click **Open Review Box** to launch Google Maps.
+5. Paste the review, add a rating and submit.
 
 ## Template Persistence
 
 Custom templates are saved in your browser's `localStorage`. They are loaded when the app starts and automatically updated whenever templates are added, removed, or generated, so your changes persist across sessions.
+
+Staff names are not stored anywhere—they exist only for your current session and are automatically woven into the review text in a natural way when provided.
 
 ## Additional Scripts
 

--- a/src/components/StaffSelector.tsx
+++ b/src/components/StaffSelector.tsx
@@ -1,0 +1,41 @@
+import { X, Check } from 'lucide-react';
+
+interface StaffSelectorProps {
+  staffName: string;
+  onChange: (name: string) => void;
+}
+
+const StaffSelector = ({ staffName, onChange }: StaffSelectorProps) => (
+  <div className="bg-white rounded-lg shadow-lg p-4 sm:p-6 md:p-8 mb-4 sm:mb-6 md:mb-8">
+    <h2 className="text-lg sm:text-xl md:text-2xl font-semibold mb-3 sm:mb-4">
+      Staff Member (optional)
+    </h2>
+    <div className="relative">
+      <input
+        type="text"
+        value={staffName}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Enter staff name"
+        className="w-full p-3 sm:p-4 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent pr-10 text-sm sm:text-base"
+      />
+      {staffName && (
+        <button
+          onClick={() => onChange('')}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+          aria-label="Clear staff name"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+    {staffName && (
+      <p className="text-sm text-green-600 mt-2 flex items-center gap-1">
+        <Check className="w-4 h-4" />
+        Included in review
+      </p>
+    )}
+  </div>
+);
+
+export default StaffSelector;
+

--- a/src/components/TemplateManager.tsx
+++ b/src/components/TemplateManager.tsx
@@ -1,5 +1,33 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useState } from 'react';
 import { Plus, Shuffle, Sparkles, RefreshCw, Trash2 } from 'lucide-react';
+
+export const integrateStaffName = (template: string, staffName: string) => {
+  const name = staffName.trim();
+  if (!name) return template;
+
+  const replacementPatterns = [
+    { regex: /\bstaff\b/i, text: `staff, especially ${name}` },
+    { regex: /\bteam\b/i, text: `team, particularly ${name}` },
+  ];
+
+  for (const { regex, text } of replacementPatterns) {
+    if (regex.test(template)) {
+      return template.replace(regex, text);
+    }
+  }
+
+  const endings = [
+    `Special thanks to ${name} for the excellent assistance.`,
+    `${name} made the visit even better with top-notch service.`,
+    `Thanks to ${name} for being so helpful and professional.`,
+    `If you go, ask for ${name} – they were wonderful.`,
+    `${name}'s support really stood out during my visit.`,
+  ];
+
+  const ending = endings[Math.floor(Math.random() * endings.length)];
+  return `${template} ${ending}`;
+};
 
 interface TemplateManagerProps {
   templates: string[];
@@ -10,6 +38,7 @@ interface TemplateManagerProps {
   onAddTemplate: (template: string) => void;
   onRemoveTemplate: (index: number) => void;
   isGenerating: boolean;
+  staffName: string;
 }
 
 const TemplateManager = ({
@@ -21,9 +50,26 @@ const TemplateManager = ({
   onAddTemplate,
   onRemoveTemplate,
   isGenerating,
+  staffName,
 }: TemplateManagerProps) => {
   const [showAddTemplate, setShowAddTemplate] = useState(false);
   const [newTemplate, setNewTemplate] = useState('');
+
+  const highlightedTemplate = () => {
+    const text = integrateStaffName(templates[selectedTemplate], staffName);
+    if (!staffName.trim()) return text;
+    const escaped = staffName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const parts = text.split(new RegExp(`(${escaped})`, 'gi'));
+    return parts.map((part, i) =>
+      part.toLowerCase() === staffName.trim().toLowerCase() ? (
+        <mark key={i} className="bg-yellow-200">
+          {part}
+        </mark>
+      ) : (
+        part
+      )
+    );
+  };
 
   const handleAdd = () => {
     if (newTemplate.trim()) {
@@ -86,7 +132,7 @@ const TemplateManager = ({
       <div className="relative">
         <div className="bg-gray-50 p-4 sm:p-6 rounded-lg border min-h-32">
           <p className="text-gray-800 leading-relaxed text-sm sm:text-base md:text-lg">
-            {templates[selectedTemplate]}
+            {highlightedTemplate()}
           </p>
         </div>
         {templates.length > 1 && (

--- a/src/review-launcher.tsx
+++ b/src/review-launcher.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import BusinessSelector from './components/BusinessSelector';
-import TemplateManager from './components/TemplateManager';
+import StaffSelector from './components/StaffSelector';
+import TemplateManager, { integrateStaffName } from './components/TemplateManager';
 import ReviewActions from './components/ReviewActions';
 import ShareTool from './components/ShareTool';
 import { businesses, type BusinessKey } from './data/businesses';
@@ -12,6 +13,7 @@ const ReviewLauncher = () => {
   const [copySuccess, setCopySuccess] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [templates, setTemplates] = useState<Record<BusinessKey, string[]>>(initialTemplates);
+  const [staffName, setStaffName] = useState('');
 
   useEffect(() => {
     const stored = localStorage.getItem('templates');
@@ -32,7 +34,10 @@ const ReviewLauncher = () => {
   }, [templates]);
 
   const handleLaunchReview = async () => {
-    const reviewText = templates[selectedBusiness][selectedTemplate];
+    const reviewText = integrateStaffName(
+      templates[selectedBusiness][selectedTemplate],
+      staffName,
+    );
     const business = businesses[selectedBusiness];
 
     try {
@@ -229,6 +234,8 @@ const ReviewLauncher = () => {
           onSelect={setSelectedBusiness}
         />
 
+        <StaffSelector staffName={staffName} onChange={setStaffName} />
+
         <TemplateManager
           templates={currentTemplates}
           selectedTemplate={selectedTemplate}
@@ -238,6 +245,7 @@ const ReviewLauncher = () => {
           onAddTemplate={handleAddTemplate}
           onRemoveTemplate={handleRemoveTemplate}
           isGenerating={isGenerating}
+          staffName={staffName}
         />
 
         <ReviewActions onLaunch={handleLaunchReview} copySuccess={copySuccess} />


### PR DESCRIPTION
## Summary
- add optional staff selector input
- weave staff member names into review templates and highlight them in previews
- document staff personalization and session-only handling

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c92df6ac832ba45b0cd11f380d47